### PR TITLE
Fix repo links in blueprints

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -6,9 +6,9 @@ author:
     name: Trilby Media
     email: hello@trilby.media
     url: https://trilby.media
-homepage: https://github.com/trilbymedia/grav-prism-highlight
+homepage: https://github.com/trilbymedia/grav-plugin-prism-highlight
 keywords: highlight, plugin, code, prism.js
-bugs: https://github.com/trilbymedia/grav-prism-highlight/issues
+bugs: https://github.com/trilbymedia/grav-plugin-prism-highlight/issues
 license: MIT
 
 form:


### PR DESCRIPTION
Noticed this while trying to get to the repo from the plugin page in Grav Admin... ;)